### PR TITLE
fix issue when compiling toolchain with gcc 6.x

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,6 @@
 BUILD_DIR ?= $(CURDIR)/build
 PKG_DIR ?= $(CURDIR)/install
+TOOL_PATCH_DIR ?= $(CURDIR)/toolchain-patches
 
 .PHONY: build
 
@@ -8,6 +9,14 @@ PATCH_FILES = gcc.c gcse.c target.def builtins.c omp-low.c ira-color.c doc/tm.te
 build:
 	if [ ! -e toolchain ]; then git clone https://github.com/riscv/riscv-gnu-toolchain.git toolchain; fi
 	cd toolchain && git checkout d038d596dc1d8e47ace22ab742cd40c2f22d659e
+	if [ -d $(TOOL_PATCH_DIR) ]; then \
+		cd toolchain; \
+		FILES=$$(ls $(TOOL_PATCH_DIR)/*.patch | sort); \
+		for tmp in $$FILES; do \
+			test=$$(patch -p1 -R -N --dry-run <$$tmp 1>/dev/null 2>&1; echo $$?);  \
+			if [ "$$test" != "0" ]; then patch -p1 -N <$$tmp; fi \
+		done; \
+	fi
 
 	mkdir -p $(BUILD_DIR)
 	cd $(BUILD_DIR) && $(CURDIR)/toolchain/configure --with-xlen=32 --with-arch=IM --disable-atomic --disable-float --disable-multilib --prefix=$(PKG_DIR)

--- a/toolchain-patches/001-fix-gcc-6-compilation-issue.patch
+++ b/toolchain-patches/001-fix-gcc-6-compilation-issue.patch
@@ -1,0 +1,129 @@
+diff --git a/patches/gcc b/patches/gcc
+index 5561fd1..e30e714 100644
+--- a/patches/gcc
++++ b/patches/gcc
+@@ -340,3 +340,124 @@ diff -ru gcc-5.1.0.orig/libsanitizer/sanitizer_common/sanitizer_platform_limits_
+       test x"$glibcxx_cv_c99_stdlib" = x"no" ||
+       test x"$glibcxx_cv_c99_wchar" = x"no"; then
+ 
++diff -Nrup original-gcc/gcc/cp/cfns.gperf gcc/gcc/cp/cfns.gperf
++--- original-gcc/gcc/cp/cfns.gperf	2016-10-04 12:01:14.659601005 +0100
+++++ gcc/gcc/cp/cfns.gperf	2016-10-04 12:01:57.345601596 +0100
++@@ -1,3 +1,5 @@
+++%language=C++
+++%define class-name libc_name
++ %{
++ /* Copyright (C) 2000-2015 Free Software Foundation, Inc.
++ 
++@@ -16,14 +18,6 @@ for more details.
++ You should have received a copy of the GNU General Public License
++ along with GCC; see the file COPYING3.  If not see
++ <http://www.gnu.org/licenses/>.  */
++-#ifdef __GNUC__
++-__inline
++-#endif
++-static unsigned int hash (const char *, unsigned int);
++-#ifdef __GNUC__
++-__inline
++-#endif
++-const char * libc_name_p (const char *, unsigned int);
++ %}
++ %%
++ # The standard C library functions, for feeding to gperf; the result is used
++diff -Nrup original-gcc/gcc/cp/cfns.h gcc/gcc/cp/cfns.h
++--- original-gcc/gcc/cp/cfns.h	2016-10-04 12:01:14.656601005 +0100
+++++ gcc/gcc/cp/cfns.h	2016-10-04 12:01:57.346601596 +0100
++@@ -1,5 +1,5 @@
++-/* ANSI-C code produced by gperf version 3.0.3 */
++-/* Command-line: gperf -o -C -E -k '1-6,$' -j1 -D -N libc_name_p -L ANSI-C cfns.gperf  */
+++/* C++ code produced by gperf version 3.0.4 */
+++/* Command-line: gperf -o -C -E -k '1-6,$' -j1 -D -N libc_name_p -L C++ --output-file cfns.h cfns.gperf  */
++ 
++ #if !((' ' == 32) && ('!' == 33) && ('"' == 34) && ('#' == 35) \
++       && ('%' == 37) && ('&' == 38) && ('\'' == 39) && ('(' == 40) \
++@@ -28,7 +28,7 @@
++ #error "gperf generated tables don't work with this execution character set. Please report a bug to <bug-gnu-gperf@gnu.org>."
++ #endif
++ 
++-#line 1 "cfns.gperf"
+++#line 3 "cfns.gperf"
++ 
++ /* Copyright (C) 2000-2015 Free Software Foundation, Inc.
++ 
++@@ -47,25 +47,18 @@ for more details.
++ You should have received a copy of the GNU General Public License
++ along with GCC; see the file COPYING3.  If not see
++ <http://www.gnu.org/licenses/>.  */
++-#ifdef __GNUC__
++-__inline
++-#endif
++-static unsigned int hash (const char *, unsigned int);
++-#ifdef __GNUC__
++-__inline
++-#endif
++-const char * libc_name_p (const char *, unsigned int);
++ /* maximum key range = 391, duplicates = 0 */
++ 
++-#ifdef __GNUC__
++-__inline
++-#else
++-#ifdef __cplusplus
++-inline
++-#endif
++-#endif
++-static unsigned int
++-hash (register const char *str, register unsigned int len)
+++class libc_name
+++{
+++private:
+++  static inline unsigned int hash (const char *str, unsigned int len);
+++public:
+++  static const char *libc_name_p (const char *str, unsigned int len);
+++};
+++
+++inline unsigned int
+++libc_name::hash (register const char *str, register unsigned int len)
++ {
++   static const unsigned short asso_values[] =
++     {
++@@ -122,14 +115,8 @@ hash (register const char *str, register
++   return hval + asso_values[(unsigned char)str[len - 1]];
++ }
++ 
++-#ifdef __GNUC__
++-__inline
++-#ifdef __GNUC_STDC_INLINE__
++-__attribute__ ((__gnu_inline__))
++-#endif
++-#endif
++ const char *
++-libc_name_p (register const char *str, register unsigned int len)
+++libc_name::libc_name_p (register const char *str, register unsigned int len)
++ {
++   enum
++     {
++diff -Nrup original-gcc/gcc/cp/except.c gcc/gcc/cp/except.c
++--- original-gcc/gcc/cp/except.c	2016-10-04 12:01:14.659601005 +0100
+++++ gcc/gcc/cp/except.c	2016-10-04 12:01:57.346601596 +0100
++@@ -1040,7 +1040,8 @@ nothrow_libfn_p (const_tree fn)
++      unless the system headers are playing rename tricks, and if
++      they are, we don't want to be confused by them.  */
++   id = DECL_NAME (fn);
++-  return !!libc_name_p (IDENTIFIER_POINTER (id), IDENTIFIER_LENGTH (id));
+++  return !!libc_name::libc_name_p (IDENTIFIER_POINTER (id),
+++				   IDENTIFIER_LENGTH (id));
++ }
++ 
++ /* Returns nonzero if an exception of type FROM will be caught by a
++diff -Nrup original-gcc/gcc/cp/Make-lang.in gcc/gcc/cp/Make-lang.in
++--- original-gcc/gcc/cp/Make-lang.in	2016-10-04 12:01:14.660601005 +0100
+++++ gcc/gcc/cp/Make-lang.in	2016-10-04 12:01:57.345601596 +0100
++@@ -111,7 +111,7 @@ else
++ # deleting the $(srcdir)/cp/cfns.h file.
++ $(srcdir)/cp/cfns.h:
++ endif
++-	gperf -o -C -E -k '1-6,$$' -j1 -D -N 'libc_name_p' -L ANSI-C \
+++	gperf -o -C -E -k '1-6,$$' -j1 -D -N 'libc_name_p' -L C++ \
++ 		$(srcdir)/cp/cfns.gperf --output-file $(srcdir)/cp/cfns.h
++ 
++ #


### PR DESCRIPTION
compiling riscv gcc 5.2.0 with gcc 6.x will result in the following error:

cfns.gperf:101:1: error: ‘const char\* libc_name_p(const char_, unsigned int)’ redeclared inline with ‘gnu_inline’ attribute
cfns.gperf:26:14: note: ‘const char_ libc_name_p(const char_, unsigned int)’ previously declared here
cfns.gperf: At global scope:
cfns.gperf:26:14: warning: inline function ‘const char_ libc_name_p(const char*, unsigned int)’ used but never defined

Mainline gcc has already a patch for it.
Apply the patch to toolchain/patches/gcc

Signed-off-by: Jean-Paul Etienne fractalclone@gmail.com
