### PR TITLE
Update 001-fix-gcc-6-compilation-issue.patch

### DIFF
--- a/toolchain-patches/001-fix-gcc-6-compilation-issue.patch
+++ b/toolchain-patches/001-fix-gcc-6-compilation-issue.patch
@@ -126,4 +126,4 @@ index 5561fd1..e30e714 100644
 ++	gperf -o -C -E -k '1-6,$$' -j1 -D -N 'libc_name_p' -L C++ \
 + 		$(srcdir)/cp/cfns.gperf --output-file $(srcdir)/cp/cfns.h
 + 
-+ #
++ #


### PR DESCRIPTION
Error when patching, there is a wired char at the end of the file.